### PR TITLE
Transparency Hotfix

### DIFF
--- a/Assets/app/LinkToPoints.cs
+++ b/Assets/app/LinkToPoints.cs
@@ -37,9 +37,9 @@ public class LinkToPoints : MonoBehaviour
             var end = spiral.zeta.ToVector2();
 
             // Define your colors here
-            Color equalColor = Color.green; // For equal lengths
-            Color startColor = Color.red;   // Starting color for unequal lengths
-            Color endColor = Color.blue;    // Ending color for unequal lengths
+            Color equalColor = Color.green * new Color(1, 1, 1, transparency.value); // For equal lengths
+            Color startColor = Color.red * new Color(1, 1, 1, transparency.value);   // Starting color for unequal lengths
+            Color endColor = Color.blue * new Color(1, 1, 1, transparency.value);    // Ending color for unequal lengths
 
             // get 100 starting points evenly from pt1 to pt2
             var numPoints = 1000f;


### PR DESCRIPTION
The colors that determine the LinksToPoints triangles are now multiplied by the transparency slider value.