### PR TITLE
Load Last Active Scene on Start

### DIFF
--- a/Assets/app/App.cs
+++ b/Assets/app/App.cs
@@ -133,10 +133,18 @@ public class App : ImmediateModeShapeDrawer
 
     void OnApplicationQuit()
     {
+        UpdateActiveSceneOnStart(SceneManager.GetActiveScene().name);
     }
 
     public void Start()
     {
+        // checks if we are on the correct scene when we start the app
+        string sceneOnStart = PlayerPrefs.GetString("ActiveSceneOnStart");
+        if(sceneOnStart != SceneManager.GetActiveScene().name) {
+            SceneManager.LoadScene(sceneOnStart);
+            return;
+        }
+
         Imag = imagDisplay.Value;
         targetImag = (float)Imag;
 
@@ -291,6 +299,15 @@ public class App : ImmediateModeShapeDrawer
 
     public void onClick()
     {
-        SceneManager.LoadScene("~Input-Output");
+        string nextScene = "~Input-Output";
+        // since we check active scene on load whenever we change scenes we need to update the playerPref before the scene changes.
+        UpdateActiveSceneOnStart(nextScene);
+        SceneManager.LoadScene(nextScene);
+    }
+
+    private void UpdateActiveSceneOnStart(string startScene) {
+        PlayerPrefs.SetString("ActiveSceneOnStart", startScene);
+
+        PlayerPrefs.Save();
     }
 }

--- a/Assets/input-output/IOApp.cs
+++ b/Assets/input-output/IOApp.cs
@@ -36,9 +36,18 @@ public class IOApp : ImmediateModeShapeDrawer
 
     void OnApplicationQuit()
     {
+        UpdateActiveSceneOnStart(SceneManager.GetActiveScene().name);
     }
 
-
+    void Start() 
+    {
+        // checks if we are on the correct scene when we start the app
+        string sceneOnStart = PlayerPrefs.GetString("ActiveSceneOnStart");
+        if(sceneOnStart != SceneManager.GetActiveScene().name) {
+            SceneManager.LoadScene(sceneOnStart);
+            return;
+        }
+    }
 
     void Update()
     {
@@ -47,6 +56,15 @@ public class IOApp : ImmediateModeShapeDrawer
 
     public void onClick()
     {
-        SceneManager.LoadScene("~Main");
+        string nextScene = "~Main";
+        // since we check active scene on load whenever we change scenes we need to update the playerPref before the scene changes.
+        UpdateActiveSceneOnStart(nextScene);
+        SceneManager.LoadScene(nextScene);
+    }
+
+    private void UpdateActiveSceneOnStart(string startScene) {
+        PlayerPrefs.SetString("ActiveSceneOnStart", startScene);
+
+        PlayerPrefs.Save();
     }
 }


### PR DESCRIPTION
Checks the ActiveSceneOnStart playerPref when the app starts and updates it as the scenes change